### PR TITLE
较大幅度的修改，增加在调用 .file() 和 .stream() 时指定流的长度的功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,36 +45,6 @@ var req = http.request(options, function (res) {
 form.pipe(req);
 ```
 
-### Uploading with known `Content-Length`
-
-If you know the `ReadStream` total size and you must to set `Content-Length`.
-You may want to use `form.setTotalStreamSize(size)`.
-
-```js
-var formstream = require('formstream');
-var http = require('http');
-var fs = require('fs');
-
-fs.stat('./logo.png', function (err, stat) {
-  var form = formstream();
-  form.file('file', './logo.png', 'upload-logo.png');
-  form.setTotalStreamSize(stat.size);
-  var options = {
-    method: 'POST',
-    host: 'upload.cnodejs.net',
-    path: '/store',
-    headers: form.headers()
-  };
-  var req = http.request(options, function (res) {
-    console.log('Status: %s', res.statusCode);
-    res.on('data', function (data) {
-      console.log(data.toString());
-    });
-  });
-  form.pipe(req);
-});
-```
-
 ### Chaining
 
 ```js
@@ -83,8 +53,7 @@ var form = require('formstream')();
 
 form.field('status', 'share picture')
     .field('access_token', 'dk10f88bhza-39kgna.d91')
-    .file('pic', './logo.png', 'logo.png')
-    .setTotalStreamSize(stat('./logo.png').size)
+    .file('pic', './logo.png', 'logo.png', stat('./logo.png').size)
     .pipe(/* your request stream */);
 ```
 
@@ -152,22 +121,6 @@ Add a readable stream as a file to upload. Event 'error' will be emitted if an e
 - **filename** String - The file name that tells the remote server
 - ***contentType*** String - Optional. Content-Type (aka. MIME Type) of content (will be infered with `filename` if empty)
 - ***size*** Number - Optional. Size of the stream (will not generate `Content-Length` header if not specified)
-
-#### Returns
-
-`form`
-
-### FormStream#setTotalStreamSize([size])
-
-**[Deprecated]**
-
-This method is used to set the total length of all streams if you want a `Content-Length` header sent with the POST request.
-
-This method is currently **DEPRECATED** and you may specify sizes of each stream or file when calling `FormStream#file` or `FormStream#sream`. In this case this method will **NOT** make any sense if all streams and files are added with a known size.
-
-#### Arguments
-
-- ***size*** Number - Defaults to 0. Size of total stream in bytes.
 
 #### Returns
 

--- a/lib/formstream.js
+++ b/lib/formstream.js
@@ -48,11 +48,14 @@ function FormStream() {
   }
 
   FormStream.super_.call(this);
+
   this._boundary = this._generateBoundary();
   this._streams = [];
-  this._fields = [];
   this._buffers = [];
   this._endData = new Buffer(PADDING + this._boundary + PADDING + NEW_LINE);
+  this._contentLength = 0;
+  this._isAllStreamSizeKnown = true;
+  this._knownStreamSize = 0;
 }
 
 util.inherits(FormStream, Stream);
@@ -70,37 +73,21 @@ FormStream.prototype._generateBoundary = function() {
   return boundary;
 };
 
-/**
- * Set total stream size.
- *
- * You know total stream data size and you want to set `Content-Length` in headers.
- */
 FormStream.prototype.setTotalStreamSize = function (size) {
-  size = size || 0;
-  // plus fileds data size
-  this._formatFields();
-  if (this._fieldsData) {
-    size += this._fieldsData.length;
+  // this method should not make any sense if the length of each stream is known.
+  if (this._isAllStreamSizeKnown) {
+    return this;
   }
 
-  // plus stream field data size
+  size = size || 0;
+
   for (var i = 0; i < this._streams.length; i++) {
-    var item = this._streams[i];
-    size += item[0].length;
+    size += this._streams[i][0].length;
     size += NEW_LINE_BUFFER.length; // stream field end pedding size
   }
 
-  // plus buffers size
-  for (var i = 0; i < this._buffers.length; i++) {
-    var item = this._buffers[i];
-    size += item[0].length;
-    size += item[1].length;
-    size += NEW_LINE_BUFFER.length;
-  }
-
-  // end padding data size
-  size += this._endData.length;
-  this._contentLength = size;
+  this._knownStreamSize = size;
+  this._isAllStreamSizeKnown = true;
 
   return this;
 };
@@ -109,113 +96,138 @@ FormStream.prototype.headers = function (options) {
   var headers = {
     'Content-Type': 'multipart/form-data; boundary=' + this._boundary
   };
-  if (typeof this._contentLength === 'number') {
+
+  // calculate total stream size
+  this._contentLength += this._knownStreamSize;
+
+  // calculate length of end padding
+  this._contentLength += this._endData.length;
+
+  if (this._isAllStreamSizeKnown) {
     headers['Content-Length'] = String(this._contentLength);
   }
+
   if (options) {
     for (var k in options) {
       headers[k] = options[k];
     }
   }
+
   return headers;
 };
 
-FormStream.prototype.file = function (name, filepath, filename) {
+FormStream.prototype.file = function (name, filepath, filename, filesize) {
   var mimeType = mime.lookup(filepath);
-  if (!filename) {
+
+  if (typeof filename === 'number' && !filesize) {
+    filesize = filename;
+    filename = path.basename(filepath);
+  } else if (!filename) {
     filename = path.basename(filepath);
   }
-  this.stream(name, fs.createReadStream(filepath), filename, mimeType);
 
-  return this;
+  var stream = fs.createReadStream(filepath);
+
+  return this.stream(name, stream, filename, mimeType, filesize);
 };
 
 FormStream.prototype.field = function (name, value) {
-  this._fields.push([name, value]);
-  process.nextTick(this.resume.bind(this));
-
-  return this;
+  var buffer = new Buffer(value);
+  return this.buffer(name, buffer);
 };
 
-FormStream.prototype.stream = function (name, stream, filename, mimeType) {
-  mimeType = mimeType || mime.lookup(filename);
+FormStream.prototype.stream = function (name, stream, filename, mimeType, size) {
+  if (typeof mimeType === 'number' && !size) {
+    size = mimeType;
+    mimeType = mime.lookup(filename);
+  } else if (!mimeType) {
+    mimeType = mime.lookup(filename);
+  }
+
   stream.on('error', this.emit.bind(this, 'error'));
+
+  var leading = this._leading({ name: name, filename: filename }, mimeType);
+
   var ps = parseStream().pause();
   stream.pipe(ps);
-  this._streams.push([
-    this._formatStreamField(name, filename, mimeType),
-    ps
-  ]);
+
+  this._streams.push([leading, ps]);
+
+  // if the size of this stream is known, plus the total content-length;
+  // otherwise, content-length is unknown.
+  if (typeof size === 'number') {
+    this._knownStreamSize += leading.length;
+    this._knownStreamSize += size;
+    this._knownStreamSize += NEW_LINE_BUFFER.length;
+  } else {
+    this._isAllStreamSizeKnown = false;
+  }
+
   process.nextTick(this.resume.bind(this));
 
   return this;
 };
 
 FormStream.prototype.buffer = function (name, buffer, filename, mimeType) {
-  mimeType = mimeType || mime.lookup(filename);
-  this._buffers.push([
-    this._formatStreamField(name, filename, mimeType),
-    buffer
-  ]);
+  if (filename && !mimeType) {
+    mimeType = mime.lookup(filename);
+  }
+
+  var disposition = { name: name }
+  if (filename) {
+    disposition.filename = filename
+  }
+
+  var leading = this._leading(disposition, mimeType);
+
+  this._buffers.push([leading, buffer]);
+
+  // plus buffer length to total content-length
+  this._contentLength += leading.length;
+  this._contentLength += buffer.length;
+  this._contentLength += NEW_LINE_BUFFER.length;
+
   process.nextTick(this.resume.bind(this));
 
   return this;
 };
 
-FormStream.prototype._emitEnd = function () {
-  // ending format:
-  //
-  // --{boundary}--\r\n
-  this.emit('data', this._endData);
-  this.emit('end');
-};
+FormStream.prototype._leading = function (disposition, type) {
+  var leading = [PADDING + this._boundary];
 
-FormStream.prototype._formatFields = function () {
-  if (!this._fields.length) {
-    return;
+  var disps = [];
+
+  if (disposition) {
+    for (var k in disposition) {
+      disps.push(k + '="' + disposition[k] + '"');
+    }
   }
 
-  var lines = '';
-  for (var i = 0; i < this._fields.length; i++) {
-    var field = this._fields[i];
-    lines += PADDING + this._boundary + NEW_LINE;
-    lines += 'Content-Disposition: form-data; name="' + field[0] + '"' + NEW_LINE;
-    lines += NEW_LINE;
-    lines += field[1];
-    lines += NEW_LINE;
-  }
-  this._fieldsData = new Buffer(lines);
-  this._fields = [];
-};
+  leading.push('Content-Disposition: form-data; ' + disps.join('; '));
 
-FormStream.prototype._emitFields = function () {
-  this._formatFields();
-  if (this._fieldsData) {
-    var data = this._fieldsData;
-    this._fieldsData = null;
-    this.emit('data', data);
+  if (type) {
+    leading.push('Content-Type: ' + type);
   }
+
+  leading.push('');
+  leading.push('');
+
+  return new Buffer(leading.join(NEW_LINE));
 };
 
 FormStream.prototype._emitBuffers = function () {
   if (!this._buffers.length) {
     return;
   }
+
   for (var i = 0; i < this._buffers.length; i++) {
     var item = this._buffers[i];
-    this.emit('data', item[0]);
-    this.emit('data', item[1]);
+    this.emit('data', item[0]); // part leading
+    this.emit('data', item[1]); // part content
     this.emit('data', NEW_LINE_BUFFER);
   }
-  this._buffers = [];
-};
 
-FormStream.prototype._formatStreamField = function (name, filename, mimeType) {
-  var data = PADDING + this._boundary + NEW_LINE;
-  data += 'Content-Disposition: form-data; name="' + name +'"; filename="' + filename + '"' + NEW_LINE;
-  data += 'Content-Type: ' + mimeType + NEW_LINE;
-  data += NEW_LINE;
-  return new Buffer(data);
+  this._buffers = [];
 };
 
 FormStream.prototype._emitStream = function (item) {
@@ -234,24 +246,34 @@ FormStream.prototype._emitStream = function (item) {
   stream.resume();
 };
 
+FormStream.prototype._emitEnd = function () {
+  // ending format:
+  //
+  // --{boundary}--\r\n
+  this.emit('data', this._endData);
+  this.emit('end');
+};
+
 FormStream.prototype.drain = function () {
-  this._emitFields();
   this._emitBuffers();
+
   var item = this._streams.shift();
   if (item) {
     this._emitStream(item);
   } else {
-    // end
     this._emitEnd();
   }
+
   return this;
 };
 
 FormStream.prototype.resume = function () {
   this.paused = false;
+
   if (!this._draining) {
     this._draining = true;
     this.drain();
   }
+
   return this;
 };


### PR DESCRIPTION
做了比较大的改动，主要有：
- 将几个 ._format*() 方法统一成 ._leading() 方法，字段在内部最终只有 Buffer 或 Stream 两种形式，因此 .field() 内部改用 Buffer 实现。
- .file() 和 .stream() 这两个最终产生 Stream 字段的方法接受最后一个参数作为这一字段的长度。
- 当没有产生 Stream 的字段时，始终计算 Content-Length；仅当存在一个或多个未知长度的 Stream 字段并且没有设定总长度时才不计算 Content-Length。
- 文档中废弃 .setTotalStreamSize() 方法，作为向后兼容保留。但假如所有 .file() 或 .stream() 都指定了长度，也就是说所有 Stream 的长度都是已知时，此方法不会起作用。
