### PR TITLE
Porting from new Buffer() to Buffer.from()

### DIFF
--- a/lib/formstream.js
+++ b/lib/formstream.js
@@ -33,7 +33,7 @@ var destroy = require('destroy');
 
 var PADDING = '--';
 var NEW_LINE = '\r\n';
-var NEW_LINE_BUFFER = new Buffer(NEW_LINE);
+var NEW_LINE_BUFFER =  Buffer.from(NEW_LINE);
 
 function FormStream() {
   if (!(this instanceof FormStream)) {
@@ -45,7 +45,7 @@ function FormStream() {
   this._boundary = this._generateBoundary();
   this._streams = [];
   this._buffers = [];
-  this._endData = new Buffer(PADDING + this._boundary + PADDING + NEW_LINE);
+  this._endData = Buffer.from(PADDING + this._boundary + PADDING + NEW_LINE);
   this._contentLength = 0;
   this._isAllStreamSizeKnown = true;
   this._knownStreamSize = 0;
@@ -137,7 +137,7 @@ FormStream.prototype.field = function (name, value) {
     if (typeof value === 'number') {
       value = String(value);
     }
-    value = new Buffer(value);
+    value = Buffer.from(value);
   }
   return this.buffer(name, value);
 };
@@ -222,7 +222,7 @@ FormStream.prototype._leading = function (disposition, type) {
   leading.push('');
   leading.push('');
 
-  return new Buffer(leading.join(NEW_LINE));
+  return Buffer.from(leading.join(NEW_LINE));
 };
 
 FormStream.prototype._emitBuffers = function () {

--- a/test/formstream.test.js
+++ b/test/formstream.test.js
@@ -338,9 +338,9 @@ describe('formstream.test.js', function () {
       form.field('foo', 'bar');
       form.field('name', '中文名字');
       form.field('pwd', '哈哈pwd');
-      var buffer = new Buffer('foo content');
+      var buffer = Buffer.from('foo content');
       form.buffer('file', buffer, 'foo.txt');
-      var bar = new Buffer('bar content中文');
+      var bar = Buffer.from('bar content中文');
       form.buffer('bar', bar, 'bar.js');
       var logopath = path.join(root, 'logo.png');
       form.file('logo', logopath);
@@ -375,7 +375,7 @@ describe('formstream.test.js', function () {
       form.field('foo', 'bar');
       form.field('name', '中文名字');
       form.field('pwd', '哈哈pwd');
-      var buffer = new Buffer('file content');
+      var buffer = Buffer.from('file content');
       form.buffer('file', buffer, 'foo.txt');
       var logopath = path.join(root, 'logo.png');
       form.file('logo', logopath);
@@ -417,7 +417,7 @@ describe('formstream.test.js', function () {
       var headers1 = formstream()
         .field('field', 'plain')
         .file('file', path.join(root, 'logo.png'), 'file')
-        .buffer('buffer', new Buffer(20), 'buffer')
+        .buffer('buffer', Buffer.alloc(20), 'buffer')
         .stream('stream', cunterStream('stream', 5), 'stream')
         .setTotalStreamSize(10)
         .headers();
@@ -425,7 +425,7 @@ describe('formstream.test.js', function () {
       var headers2 = formstream()
         .field('field', 'plain')
         .file('file', path.join(root, 'logo.png'), 'file', 10)
-        .buffer('buffer', new Buffer(20), 'buffer')
+        .buffer('buffer', Buffer.alloc(20), 'buffer')
         .stream('stream', cunterStream('stream', 5), 'stream', 30)
         .headers();
 
@@ -452,7 +452,7 @@ describe('formstream.test.js', function () {
 
     it('should do chaining calls with .buffer()', function () {
       var form = formstream();
-      form.buffer('foo', new Buffer('foo content'), 'bar').should.equal(form);
+      form.buffer('foo', Buffer.from('foo content'), 'bar').should.equal(form);
     });
 
     it('should do chaining calls with .stream()', function () {


### PR DESCRIPTION
Trying to resolve some deprecation errors from using the Buffer constructor. 

Found through this dependency tree:
└─┬ snowflake-sdk@1.6.14
  └─┬ urllib@2.39.1
    └── formstream@1.1.1
   
for additional reference: https://nodejs.org/en/docs/guides/buffer-constructor-deprecation

Thanks