### PR TITLE
fix: only print top 512 bytes on buffer field debug log

### DIFF
--- a/lib/formstream.js
+++ b/lib/formstream.js
@@ -214,8 +214,13 @@ FormStream.prototype.buffer = function (name, buffer, filename, mimeType) {
 
   process.nextTick(this.resume.bind(this));
   if (debug.enabled) {
-    debug('new buffer field, content size: %d\n%s%s',
-      buffer.length, leading.toString(), hex(buffer));
+    if (buffer.length > 512) {
+      debug('new buffer field, content size: %d\n%s%s',
+        buffer.length, leading.toString(), hex(buffer.slice(0, 512)));
+    } else {
+      debug('new buffer field, content size: %d\n%s%s',
+        buffer.length, leading.toString(), hex(buffer));
+    }
   }
   return this;
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced buffer logging in forms to include content size and hex representation, improving debugging and monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->